### PR TITLE
Afl submodule

### DIFF
--- a/afl/Makefile
+++ b/afl/Makefile
@@ -5,10 +5,8 @@ SRCS=	kcov_afl.c
 
 HAVE_DEBUGCON_PRINTF=no
 
-.if ${HAVE_DEBUGCON_PRINTF} == "yes"
-CPPFLAGS+=	-I/~/workspace/debugcon_printf/
+CPPFLAGS+=	-I/root/workspace/kcov_4/debugcon_printf/
 CPPFLAGS+=	-DHAVE_DEBUGCON_PRINTF
-.endif
 CPPFLAGS+=	-DDIAGNOSTIC
 
 

--- a/afl/Makefile
+++ b/afl/Makefile
@@ -1,0 +1,10 @@
+#	$NetBSD$
+
+KMOD=	kcov_afl
+SRCS=	kcov_afl.c
+
+CPPFLAGS+=	-I/root/workspace/kcov_4/debugcon_printf/
+CPPFLAGS+=	-DDIAGNOSTIC
+
+
+.include <bsd.kmodule.mk>

--- a/afl/Makefile
+++ b/afl/Makefile
@@ -3,11 +3,14 @@
 KMOD=	kcov_afl
 SRCS=	kcov_afl.c
 
-HAVE_DEBUGCON_PRINTF=no
+HAVE_DEBUGCON_PRINTF=0
 
-CPPFLAGS+=	-I/root/workspace/kcov_4/debugcon_printf/
+.if ${HAVE_DEBUGCON_PRINTF} == 1
+CPPFLAGS_DBGCON!=pkg-config --cflags debugcon_printf
+CPPFLAGS+=${CPPFLAGS_DBGCON}
 CPPFLAGS+=	-DHAVE_DEBUGCON_PRINTF
-CPPFLAGS+=	-DDIAGNOSTIC
+.endif
 
+CPPFLAGS+=	-DDIAGNOSTIC
 
 .include <bsd.kmodule.mk>

--- a/afl/Makefile
+++ b/afl/Makefile
@@ -3,8 +3,12 @@
 KMOD=	kcov_afl
 SRCS=	kcov_afl.c
 
-$(error uncomment clone and setup debugcon_printf as below)
-# CPPFLAGS+=	-I/~/workspace/debugcon_printf/
+HAVE_DEBUGCON_PRINTF=no
+
+.if ${HAVE_DEBUGCON_PRINTF} == "yes"
+CPPFLAGS+=	-I/~/workspace/debugcon_printf/
+CPPFLAGS+=	-DHAVE_DEBUGCON_PRINTF
+.endif
 CPPFLAGS+=	-DDIAGNOSTIC
 
 

--- a/afl/Makefile
+++ b/afl/Makefile
@@ -3,7 +3,8 @@
 KMOD=	kcov_afl
 SRCS=	kcov_afl.c
 
-CPPFLAGS+=	-I/root/workspace/kcov_4/debugcon_printf/
+$(error uncomment clone and setup debugcon_printf as below)
+# CPPFLAGS+=	-I/~/workspace/debugcon_printf/
 CPPFLAGS+=	-DDIAGNOSTIC
 
 

--- a/afl/README.md
+++ b/afl/README.md
@@ -1,7 +1,14 @@
 # AFL module for kcov Framework
+Simple module that exposes to the User Space AFL like SHM region that can be consumed by modified AFL.    
+This module demonstrate how to write own extension to the NetBSD [kcov(4)](https://netbsd.gw.com/cgi-bin/man-cgi?kcov++NetBSD-current).
 
 ## Compilation
+Compilation require debugcon_printf, can be downloaded [from here](https://github.com/krytarowski/debugcon_printf)
 
 ```
-make S=/root/workspace/mybsd/src/sys
+# Compile kernel module
+make S=/~/workspace/mybsd/src/sys
+
+# Compile user space stub 
+gcc ./main.c -o afl_test
 ```

--- a/afl/README.md
+++ b/afl/README.md
@@ -1,0 +1,7 @@
+# AFL module for kcov Framework
+
+## Compilation
+
+```
+make S=/root/workspace/mybsd/src/sys
+```

--- a/afl/README.md
+++ b/afl/README.md
@@ -7,8 +7,8 @@ Compilation require debugcon_printf, can be downloaded [from here](https://githu
 
 ```
 # Compile kernel module
-make S=/~/workspace/mybsd/src/sys
+make S=/workspace/netbsd/src/sys
 
 # Compile user space stub 
-gcc ./main.c -o afl_test
+gcc ./example.c -o afl_test
 ```

--- a/afl/example.c
+++ b/afl/example.c
@@ -71,10 +71,11 @@ main(void)
                 err(1, "ioctl: KCOV_IOC_DISABLE");
 	/* Print SHM region after the tracing */
 	for (i = 0; i < size; ++i) {
+		unsigned char x = (unsigned char)cover[i];
+		printf("%03x ", x);
 		if (i % 32 == 31) printf("\n");
-
-		printf("%03x ", (char)cover[i]);
 	}
+	printf("\n");
         if (munmap(cover, size) == -1)
                 err(1, "munmap");
         close(fd);

--- a/afl/example.c
+++ b/afl/example.c
@@ -1,0 +1,48 @@
+#include <err.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <sys/ioccom.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <sys/kcov.h>
+
+int
+main(void)
+{
+        char *cover, n;
+	int i = 0;
+        uint64_t size = (1 << 16);
+        int fd;
+        int mode;
+
+        fd = open("/dev/kcov", O_RDWR);
+        if (fd == -1)
+                err(1, "open");
+        if (ioctl(fd, KCOV_IOC_SETBUFSIZE, &size) == -1)
+                err(1, "ioctl: KCOV_IOC_SETBUFSIZE");
+        cover = mmap(NULL, size,
+            PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+        if (cover == MAP_FAILED)
+                err(1, "mmap");
+        mode = KCOV_MODE_TRACE_PC;
+        if (ioctl(fd, KCOV_IOC_ENABLE, &mode) == -1)
+                err(1, "ioctl: KCOV_IOC_ENABLE");
+        read(-1, NULL, 0); /* syscall paths to be traced */
+	printf("#: PRINTF TEST! \n");
+	
+        if (ioctl(fd, KCOV_IOC_DISABLE) == -1)
+                err(1, "ioctl: KCOV_IOC_DISABLE");
+	for (i = 0; i < size; ++i) {
+		if (i % 32 == 31) printf("\n");
+	
+		printf("%03x ", (char)cover[i]);
+	}
+        if (munmap(cover, size) == -1)
+                err(1, "munmap");
+        close(fd);
+
+        return 0;
+}

--- a/afl/example.c
+++ b/afl/example.c
@@ -1,3 +1,33 @@
+/*	$NetBSD$	*/
+
+/*-
+ * Copyright (c) 2019 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software contributed to The NetBSD Foundation
+ * by
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 #include <err.h>
 #include <fcntl.h>
 #include <stdio.h>
@@ -12,8 +42,8 @@
 int
 main(void)
 {
-	/* AFL by default uses 64kB SHM region for tracing see: 
-	 * https://github.com/mirrorer/afl/blob/master/docs/technical_details.txt#L37 */
+	/* AFL by default uses 64kB SHM region for tracing see:
+	 * http://lcamtuf.coredump.cx/afl/technical_details.txt */
 	uint64_t size = (1 << 16);
         char *cover, n;
 	int i = 0;
@@ -33,16 +63,16 @@ main(void)
         if (ioctl(fd, KCOV_IOC_ENABLE, &mode) == -1)
                 err(1, "ioctl: KCOV_IOC_ENABLE");
 	/* Start of code to be traced */
-        read(-1, NULL, 0); 
+        read(-1, NULL, 0);
 	printf("#: PRINTF TRACE!\n");
 	/* End of traced code */
-	
+
         if (ioctl(fd, KCOV_IOC_DISABLE) == -1)
                 err(1, "ioctl: KCOV_IOC_DISABLE");
 	/* Print SHM region after the tracing */
 	for (i = 0; i < size; ++i) {
 		if (i % 32 == 31) printf("\n");
-	
+
 		printf("%03x ", (char)cover[i]);
 	}
         if (munmap(cover, size) == -1)

--- a/afl/example.c
+++ b/afl/example.c
@@ -12,9 +12,11 @@
 int
 main(void)
 {
+	/* AFL by default uses 64kB SHM region for tracing see: 
+	 * https://github.com/mirrorer/afl/blob/master/docs/technical_details.txt#L37 */
+	uint64_t size = (1 << 16);
         char *cover, n;
 	int i = 0;
-        uint64_t size = (1 << 16);
         int fd;
         int mode;
 
@@ -24,17 +26,20 @@ main(void)
         if (ioctl(fd, KCOV_IOC_SETBUFSIZE, &size) == -1)
                 err(1, "ioctl: KCOV_IOC_SETBUFSIZE");
         cover = mmap(NULL, size,
-            PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+                     PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
         if (cover == MAP_FAILED)
                 err(1, "mmap");
         mode = KCOV_MODE_TRACE_PC;
         if (ioctl(fd, KCOV_IOC_ENABLE, &mode) == -1)
                 err(1, "ioctl: KCOV_IOC_ENABLE");
-        read(-1, NULL, 0); /* syscall paths to be traced */
-	printf("#: PRINTF TEST! \n");
+	/* Start of code to be traced */
+        read(-1, NULL, 0); 
+	printf("#: PRINTF TRACE!\n");
+	/* End of traced code */
 	
         if (ioctl(fd, KCOV_IOC_DISABLE) == -1)
                 err(1, "ioctl: KCOV_IOC_DISABLE");
+	/* Print SHM region after the tracing */
 	for (i = 0; i < size; ++i) {
 		if (i % 32 == 31) printf("\n");
 	

--- a/afl/example.c
+++ b/afl/example.c
@@ -5,7 +5,7 @@
  * All rights reserved.
  *
  * This code is derived from software contributed to The NetBSD Foundation
- * by
+ * by Maciej Grochowski
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,16 +28,21 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#include <err.h>
-#include <fcntl.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <unistd.h>
+
+
+#include <sys/cdefs.h>
+__RCSID("$NetBSD$");
 
 #include <sys/ioccom.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
 #include <sys/kcov.h>
+
+#include <err.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
 
 int
 main(void)

--- a/afl/kcov_afl.c
+++ b/afl/kcov_afl.c
@@ -4,9 +4,6 @@
  * Copyright (c) 2019 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
- * This code is derived from software contributed to The NetBSD Foundation
- * by Kamil Rytarowski.
- *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
@@ -43,7 +40,7 @@ __KERNEL_RCSID(0, "$NetBSD$");
 
 #include <debugcon_printf.h>
 
-/* -------------------------- AFL utilities --------------------------- */
+/* -------------------------- AFL Long HASH --------------------------- */
 #define GOLDEN_RATIO_32 0x61C88647
 #define GOLDEN_RATIO_64 0x61C8864680B583EBull
 #define BITS_PER_LONG 	64
@@ -147,8 +144,7 @@ kcov_afl_mmap(void *priv, size_t size, off_t off, struct uvm_object **uobjp)
 	kcov_afl_t *afl;
 
 	afl = (kcov_afl_t *)priv;
-printf("#: size: %lu, off: %lu \n", size, off);
-printf("#: AFL->size:: %lu\n", afl->afl_bsize);
+
 	if ((size + off) > afl->afl_bsize)
 		return ENOMEM;
 
@@ -156,7 +152,6 @@ printf("#: AFL->size:: %lu\n", afl->afl_bsize);
 
 	*uobjp = afl->afl_uobj;
 
-printf("#: MAPPED!! size: %lu, off: %lu \n", size, off);
 	return 0;
 }
 

--- a/afl/kcov_afl.c
+++ b/afl/kcov_afl.c
@@ -1,0 +1,228 @@
+/*	$NetBSD$	*/
+
+/*-
+ * Copyright (c) 2019 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software contributed to The NetBSD Foundation
+ * by Kamil Rytarowski.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#include <sys/cdefs.h>
+__KERNEL_RCSID(0, "$NetBSD$");
+
+#include <sys/param.h>
+#include <sys/module.h>
+#include <sys/kcov.h>
+#include <sys/kmem.h>
+#include <sys/lwp.h>
+#include <sys/systm.h>
+#include <uvm/uvm.h>
+
+#include <debugcon_printf.h>
+
+/* -------------------------- AFL utilities --------------------------- */
+#define GOLDEN_RATIO_32 0x61C88647
+#define GOLDEN_RATIO_64 0x61C8864680B583EBull
+#define BITS_PER_LONG 	64
+
+static uint64_t
+_long_hash64(uint64_t val, unsigned int bits) {
+	return val * GOLDEN_RATIO_64 >> (64 - bits);
+}
+
+typedef struct afl_ctx {
+	uint8_t *afl_area;
+	struct uvm_object *afl_uobj;
+	size_t afl_bsize;
+	uint64_t afl_prev_loc;
+	lwpid_t lid;
+} kcov_afl_t;
+
+static void *
+kcov_afl_open(void)
+{
+	kcov_afl_t *afl;
+
+	afl = kmem_zalloc(sizeof(*afl), KM_SLEEP);
+
+	/* curlwp can differ for other calls, store the one from open(2) */
+	afl->lid = curlwp->l_lid;
+
+	return afl;
+}
+
+static void
+kcov_afl_free(void *priv)
+{
+	kcov_afl_t *afl;
+
+	afl = (kcov_afl_t *)priv;
+
+	if (afl->afl_area != NULL) {
+		uvm_deallocate(kernel_map, (vaddr_t)afl->afl_area, afl->afl_bsize);
+	}
+
+	kmem_free(afl, sizeof(*afl));
+}
+
+static int
+kcov_afl_setbufsize(void *priv, uint64_t size)
+{
+	kcov_afl_t *afl;
+	int error;
+
+	afl = (kcov_afl_t *)priv;
+
+	if (afl->afl_area != NULL)
+		return EEXIST;
+
+	afl->afl_bsize = size;
+	afl->afl_uobj = uao_create(afl->afl_bsize, 0);
+
+	/* Map the uobj into the kernel address space, as wired. */
+	afl->afl_area = NULL;
+	error = uvm_map(kernel_map, (vaddr_t *)&afl->afl_area, afl->afl_bsize,
+	    afl->afl_uobj, 0, 0, UVM_MAPFLAG(UVM_PROT_RW, UVM_PROT_RW,
+	    UVM_INH_SHARE, UVM_ADV_RANDOM, 0));
+	if (error) {
+		uao_detach(afl->afl_uobj);
+		return error;
+	}
+	error = uvm_map_pageable(kernel_map, (vaddr_t)afl->afl_area,
+	    (vaddr_t)afl->afl_area + afl->afl_bsize, false, 0);
+	if (error) {
+		uvm_deallocate(kernel_map, (vaddr_t)afl->afl_area, afl->afl_bsize);
+		return error;
+	}
+
+	return 0;
+}
+
+static int
+kcov_afl_enable(void *priv, int mode)
+{
+	kcov_afl_t *afl;
+
+	afl = (kcov_afl_t *)priv;
+
+	if (afl->afl_area == NULL)
+		return ENOBUFS;
+
+	return 0;
+}
+
+static int
+kcov_afl_disable(void *priv __unused)
+{
+
+	return 0;
+}
+
+static int
+kcov_afl_mmap(void *priv, size_t size, off_t off, struct uvm_object **uobjp)
+{
+	kcov_afl_t *afl;
+
+	afl = (kcov_afl_t *)priv;
+printf("#: size: %lu, off: %lu \n", size, off);
+printf("#: AFL->size:: %lu\n", afl->afl_bsize);
+	if ((size + off) > afl->afl_bsize)
+		return ENOMEM;
+
+	uao_reference(afl->afl_uobj);
+
+	*uobjp = afl->afl_uobj;
+
+printf("#: MAPPED!! size: %lu, off: %lu \n", size, off);
+	return 0;
+}
+
+static void
+kcov_afl_cov_trace_pc(void *priv, intptr_t pc)
+{
+	kcov_afl_t *afl = priv;
+
+//	debugcon_printf("#: '%x'\n", pc);
+
+	++afl->afl_area[(afl->afl_prev_loc ^ pc) & (afl->afl_bsize-1)];
+	afl->afl_prev_loc = _long_hash64(pc, BITS_PER_LONG);
+
+	return;
+}
+
+static void
+kcov_afl_cov_trace_cmp(void *priv __unused, uint64_t type __unused,
+    uint64_t arg1 __unused, uint64_t arg2 __unused, intptr_t pc __unused)
+{
+
+	/* Not implemented. */
+
+	return;
+}
+
+static struct kcov_ops kcov_afl_ops = {
+	.open = kcov_afl_open,
+	.free = kcov_afl_free,
+	.setbufsize = kcov_afl_setbufsize,
+	.enable = kcov_afl_enable,
+	.disable = kcov_afl_disable,
+	.mmap = kcov_afl_mmap,
+	.cov_trace_pc = kcov_afl_cov_trace_pc,
+	.cov_trace_cmp = kcov_afl_cov_trace_cmp
+};
+
+MODULE(MODULE_CLASS_MISC, kcov_afl, "kcov,debugcon_printf");
+
+static int
+kcov_afl_modcmd(modcmd_t cmd, void *arg __unused)
+{
+	int error;
+
+	switch (cmd) {
+	case MODULE_CMD_INIT:
+		error = kcov_ops_set(&kcov_afl_ops);
+		if (error)
+			return error;
+		debugcon_printf("AFL module loaded.\n");
+		break;
+
+	case MODULE_CMD_FINI:
+		error = kcov_ops_unset(&kcov_afl_ops);
+		if (error)
+			return error;
+		debugcon_printf("AFL module unloaded.\n");
+		break;
+
+	case MODULE_CMD_STAT:
+		debugcon_printf("AFL module status queried.\n");
+		break;
+
+	default:
+		return ENOTTY;
+	}
+
+	return 0;
+}

--- a/afl/kcov_afl.c
+++ b/afl/kcov_afl.c
@@ -38,7 +38,9 @@ __KERNEL_RCSID(0, "$NetBSD$");
 #include <sys/systm.h>
 #include <uvm/uvm.h>
 
+#if HAVE_DEBUGCON_PRINTF == yes
 #include <debugcon_printf.h>
+#endif
 
 /* -------------------------- AFL Long HASH --------------------------- */
 #define GOLDEN_RATIO_32 0x61C88647
@@ -159,9 +161,9 @@ static void
 kcov_afl_cov_trace_pc(void *priv, intptr_t pc)
 {
 	kcov_afl_t *afl = priv;
-
-//	debugcon_printf("#: '%x'\n", pc);
-
+#if HAVE_DEBUGCON_PRINTF == yes
+	debugcon_printf("#: '%x'\n", pc);
+#endif
 	++afl->afl_area[(afl->afl_prev_loc ^ pc) & (afl->afl_bsize-1)];
 	afl->afl_prev_loc = _long_hash64(pc, BITS_PER_LONG);
 
@@ -201,18 +203,24 @@ kcov_afl_modcmd(modcmd_t cmd, void *arg __unused)
 		error = kcov_ops_set(&kcov_afl_ops);
 		if (error)
 			return error;
+#if HAVE_DEBUGCON_PRINTF == yes
 		debugcon_printf("AFL module loaded.\n");
+#endif
 		break;
 
 	case MODULE_CMD_FINI:
 		error = kcov_ops_unset(&kcov_afl_ops);
 		if (error)
 			return error;
+#if HAVE_DEBUGCON_PRINTF == yes
 		debugcon_printf("AFL module unloaded.\n");
+#endif
 		break;
 
 	case MODULE_CMD_STAT:
+#if HAVE_DEBUGCON_PRINTF == yes
 		debugcon_printf("AFL module status queried.\n");
+#endif
 		break;
 
 	default:


### PR DESCRIPTION
Simple module for kcov(4) to expose AFL compatible SHM region that can be consumed via userspace fuzzer.